### PR TITLE
Task/worker class/remove approve method

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,7 +404,7 @@ job.download_csv(full, nil, force:true)
 * [Job Settings](http://success.crowdflower.com/customer/portal/articles/1373615-contributors---behavior-settings)
 * [Data Management](http://success.crowdflower.com/customer/portal/articles/1288308-data)
 * [Judgments](http://success.crowdflower.com/customer/portal/articles/1366723-job-settings---judgments)
-[Workers](http://success.crowdflower.com/customer/portal/articles/1288319-contributors---active-contributors)
+* [Workers](http://success.crowdflower.com/customer/portal/articles/1288319-contributors---active-contributors)
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
 ## Usage and Examples 
-#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples. 
+#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples (must be signed in to view).
 
 ### Access Job Info
 

--- a/README.md
+++ b/README.md
@@ -1,41 +1,146 @@
-# ruby-crowdflower
+CrowdFlower API Gem
+========
+Currently this is a toolkit for interacting with the CrowdFlower REST API. It may potentially become a complete Ruby gem for accessing and editing [CrowdFlower](http://crowdflower.com.com) jobs. 
 
-A toolkit for interacting with CrowdFlower via the REST API.
+## Table of Contents
 
-This is alpha software. Have fun!
+1. [Intstall](#Install)
+2. [Usage](#usage)
+3. [Breakdown](#breakdown)
+4. [Contribute](#contribute)
+5. [Team](#team)
+6. [License](#license)
 
-Example Usage
--------------
+## Install
 
-Specifiy either your api key or a yaml file containing the key:
-	
-	CrowdFlower.connect!( 'CrowdFlower.yml' )
-	
-Upload a CSV file for a job:
+Add this line to your application's Gemfile:
 
-	CrowdFlower::Job.upload( File.dirname(__FILE__) + "/data.csv", "text/csv" )
+    $ gem 'crowdflower'
 
-Copy an existing job into a new one:
-	
-	new_job = job.copy( :all_units => true )
-	
-Check the status of a job:
+And then execute:
 
-	job.status["tainted_judgments"]
+    $ bundle install
 
+Or install it yourself as:
 
+    $ gem install crowdflower
 
-Contributing
-------------
+## Usage
 
-1. Fork ruby-crowdflower
-2. Create a topic branch - `git checkout -b my_branch`
-3. Make your feature addition or bug fix and add tests for it.
-4. Commit, but do not mess with the rakefile, version, or history.
-5. Push to your branch - `git push origin my_branch`
-6. Create an Issue with a link to your branch
+This gem makes use of [CrowdFlower's Human API](http://success.crowdflower.com/customer/portal/articles/1288323-api-documentation). Please check out our [Terms and Conditions](http://www.crowdflower.com/legal) page for detailed usage and licensing information.
 
-Copyright
----------
+#####Specifiy either your api key or a yaml file containing the key:
 
-Copyright &copy; 2014 [CrowdFlower](http://www.crowdflower.com/). See LICENSE for details.
+```ruby
+CrowdFlower.connect!( 'CrowdFlower.yml' )
+```
+
+## Breakdown
+
+* [Base](#base)
+* [Job](#job)
+* [Judgment](#judgment)
+* [Order](#order)
+* [Unit](#unit)
+* [Worker](#worker)
+* [Crowdflower](#crowdflower)
+
+###Base
+
+####Placeholder
+
+###Job
+  * Create
+  * Get
+  * Units
+  * Copy
+  * Deban
+  * Status
+  * Upload
+  * Legend
+  * Download CSV --> Note to self: test csv vs zip
+  * Pause
+  * Resume
+  * Cancel 
+  * Update
+  * Delete
+  * Channels
+  * Enable Channels
+  * Tags
+  * Update Tags
+  * Add Tags
+  * Remove Tags
+
+###Judgment
+  * All
+  * Get
+  * Reject
+
+###Order
+  * Debit
+
+###Unit
+  * All
+  * Get
+  * Ping
+  * Judgments
+  * Create
+  * Copy
+  * Split
+  * Update
+  * Make Gold
+  * Cancel
+  * Delete
+  * Request More Judgments
+
+###Worker
+
+####Methods, Examples and Bugs
+  * Bonus
+  * Approve
+  * Reject
+  * Ban
+  * Deban
+  * Notifty
+  * Flag
+  * Deflag
+
+###Crowdflower
+
+####Does something with httparty
+
+## Contribute
+
+1. Fork the repo: https://github.com/dolores/ruby-crowdflower.git
+2. Create your topic branch (`git checkout -b my_branch`)
+3. Make changes and add tests for those changes
+3. Commit your changes, making sure not to change the rakefile, version or history (`git commit -am 'Adds cool, new README'`)
+4. Push to your branch (`git push origin my_branch`)
+5. Create an issue with a link to your branch for the pull request
+
+## Team
+
+This gem is made by CrowdFlower engineers. Check out the [CrowdFlower Team](http://www.crowdflower.com/team)!
+
+## License
+
+Copyright (c) 2014 CrowdFlower
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -318,14 +318,16 @@ worker.reject(worker_id)
 worker.reject(14952322)
 ```
 
-#####WORKER.BAN: There isn't any documentation for this method. 
+#####WORKER.BAN: Ban a specific contributor from accessing any CrowdFlower job. This makes valid contributors angry so be sure to use with caution.
+
 
 ```ruby
 worker.ban(worker_id)
 worker.ban(14952322)
 ```
 
-#####WORKER.DEBAN: There isn't any documentation for this method. 
+#####WORKER.DEBAN: Removes the ban on that contributor for when we make mistakes (it happens).
+ 
 
 ```ruby
 worker.deban(worker_id)

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ job.units.judgments(unit_id_number)
 job.units.judgments(444154130) 
 ```
 
-#####LEGEND - http://api.crowdflower.com/v1/jobs/418404/legend
+#####LEGEND: Returns all of the cml in a job; shows all questions and available answers, see example: http://api.crowdflower.com/v1/jobs/418404/legend.
 
 ```ruby
 job.legend

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 
 1. [Getting Started](#getting-started)
 2. [Usage and Examples](#usage-and-examples)
-3. [API Documentation](#api-documentation)
+3. [Helpful Documentation Links](#api-documentation)
 4. [Contribute](#contribute)
 5. [Team](#team)
 6. [License](#license)
@@ -32,7 +32,7 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 
 This gem makes use of [CrowdFlower's API](http://success.crowdflower.com/customer/portal/articles/1288323-api-documentation). To find your API key, click on your name in the upper right hand corner and select "Account" from the drop down. To create an account click [here](https://id.crowdflower.com/registrations/new?redirect_url=https%3A%2F%2Fcrowdflower.com%2Fjobs&app=make&__hssc=14529640.6.1397164984954&__hstc=14529640.8f31cd290788fdc43f4da6707700cde6.1396463439689.1397160539873.1397164984954.16&hsCtaTracking=c85b8d58-818e-4f19-a27e-83e8f55da890%7C583ca9bc-a025-43b9-806a-b329df96a8c6).
 
-#####Specifiy your api key directly in your code or store it in a yaml file:
+#####Specify your api key directly in your code or store it in a yaml file:
 
 ```ruby
 API_KEY = "YOUR_API_KEY"
@@ -41,7 +41,7 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
 ## Usage and Examples 
-#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples (must be signed in to view).3
+#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples (must be signed in to view). 
 
 ### Access Job Info
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
 ## Usage and Examples 
+#####[Example Job](api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples. 
 
 ### Access Job Info
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
 ## Usage and Examples 
-#####[Example Job](api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples. 
+#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples. 
 
 ### Access Job Info
 

--- a/README.md
+++ b/README.md
@@ -401,9 +401,9 @@ job.download_csv(full, nil, force:true)
 
 ## Helpful Documentation Links
 
-[Job Settings](http://success.crowdflower.com/customer/portal/articles/1373615-contributors---behavior-settings)
-[Data Management](http://success.crowdflower.com/customer/portal/articles/1288308-data)
-[Judgments](http://success.crowdflower.com/customer/portal/articles/1366723-job-settings---judgments)
+* [Job Settings](http://success.crowdflower.com/customer/portal/articles/1373615-contributors---behavior-settings)
+* [Data Management](http://success.crowdflower.com/customer/portal/articles/1288308-data)
+* [Judgments](http://success.crowdflower.com/customer/portal/articles/1366723-job-settings---judgments)
 [Workers](http://success.crowdflower.com/customer/portal/articles/1288319-contributors---active-contributors)
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -166,177 +166,187 @@ job.update_tags("fun", "glitter", "crowdshop")
 job.remove_tags("crowdshop") 
 ```
 
-#####UNITS - http://api.crowdflower.com/v1/jobs/418404/units
+#####UNITS: http://api.crowdflower.com/v1/jobs/418404/units
 
 ```ruby
 unit = CrowdFlower::Unit.new(job)
 ```
 
-#####View
+#####UNIT.ALL: View all units or count all units in a job; same result as job.units.
 
 ```ruby
 unit.all 
 unit.all.count
+```
+
+#####UNIT.GET: Get info about a unit by passing in the unit's ID.units.
+
+```ruby
 unit.get(unit_id)
 ```
-#####Check on a unit
+#####UNIT.PING: Returns the status of all units in a job.
 
 ```ruby
 unit.ping
 ```
 
-#####View a unit's judgments
+#####UNIT.JUDGMENTS: View all judgments for a specific unit by passing in the unit_id.
 
 ```ruby
 unit.judgments(unit_id)
 unit.judgments(444154130)
 ```
 
-#####Create from scratch
+#####UNIT.CREATE: Create a new unit.
 
 ```ruby
 unit.create("glitter_color"=>"blue") 
 unit.create("glitter_color"=>"blue", gold: true) 
 ```
 
-#####Create from copy of existing unit
+#####UNIT.COPY: Copy an existing unit.
 
 ```ruby
 unit.copy(unit_id, job_id, data = {})
 unit.copy(444154130, 418404, "glitter_color"=>"blue")
 ```
 
-#####Split
+#####UNIT.SPLIT: In cases where multiple values are stored in the cells of the same column, you can use the Split Column function to parse the data into two or more columns by specifying a delimiter (most typically a newline character).
 
 ```ruby
 unit.split(on, with = " ")
 ```
 
-#####Update 
+#####UNIT.UPDATE: Update the value of a unit's key.  
 
 ```ruby
 unit.update(unit_id, params)
 unit.update(444154130, "glitter_color"=>"green")
 ```
 
-#####Make Gold (make the unit a test question)
+#####UNIT.MAKE_GOLD: Turn an existing unit into a test question (gold) unit.
 
 ```ruby
 unit.make_gold(unit_id)
 ```
 
-#####CANCEL
+#####UNIT.CANCEL: Cancel a unit.
 
 ```ruby
 unit.cancel(unit_id)
 ```
 
-#####DELETE
+#####UNIT.DELETE: Delete a unit.
 
 ```ruby
 unit.delete(unit_id)
 ```
 
-#####REQUEST_MORE_JUDGMENTS: nb_judgments = number of additional judgments
+#####UNIT.REQUEST_MORE_JUDGMENTS: Get more answers (judgments) for a specific unit by using this method with the unit's id and the amount of requested judgments passed as params. 
 
 ```ruby
 unit.request_more_judgments(unit_id, nb_judgments = 1)
 ```
 
-#####ORDERS
+#####ORDER: Set up an order using your job's id.
 
 ```ruby
 order = CrowdFlower::Order.new(job)
+```
+
+#####ORDER.DEBIT: When a job has data(units) and properly working cml it will be ready to launch. Going to the launch tab on the job dashboard is the same as calling order.debit. 
+
+```ruby
 order.debit(units_count, channels)
 order.debit(6, "all")
 ```
 
-#####PAUSE - can only call on running jobs
+#####PAUSE: Only can be called on running jobs.
 
 ```ruby
 job.pause
 ```
 
-#####RESUME - can only call on paused or complete jobs
+#####RESUME: Only can be called on paused or completed jobs.
 
 ```ruby
 job.resume
 ```
 
-#####CANCEL - only on running or paused jobs
+#####CANCEL: Only can be called on paused jobs.
 
 ```ruby
 job.cancel
 ```
 
-#####UPDATE - access of the json attributes (see GET)
+#####UPDATE: Update any of the JSON attributes that [get](https://github.com/dolores/ruby-crowdflower/tree/chore/improve_readme#get---httpscrowdflowercomjobs418404json) can access. 
 
 ```ruby
 job.update
 job.update("project_number"=>"PN123")
 ```
 
-#####DELETE
+#####DELETE: Delete the entire job.
 
 ```ruby
 job.delete
 ```
 
-#####WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
+#####WORKERS: http://api.crowdflower.com/v1/jobs/418404/workers
 
 ```ruby
 worker = CrowdFlower::Worker.new(job) 
 ```
 
-#####BONUS: Award a bonus in cents, 200 for $2.00 and (optionally) add a message
+#####WORKER.BONUS: Award a bonus in cents, 200 for $2.00 and (optionally) add a message
 
 ```ruby
 worker.bonus(worker_id, amount, reason=nil)
 worker.bonus(23542619, 200, "You shoe shop like a pro! Thanks for the awesome answers!")
 ```
 
-#####APPROVE: There isn't any documentation for this method. 
+#####WORKER.APPROVE: There isn't any documentation for this method. 
 
 ```ruby
 worker.approve(worker_id)
 worker.approve(14952322) 
 ```
-#####REJECT: Stops contributors from completing tasks, and removes the contributors judgments from a job. Try to only use when a job is running, otherwise the completed job will lose judgments and be unable to collect replacement ones. 
+#####WORKER.REJECT: Stops contributors from completing tasks, and removes the contributors judgments from a job. Try to only use when a job is running, otherwise the completed job will lose judgments and be unable to collect replacement ones. 
 
 ```ruby
 worker.reject(worker_id)
 worker.reject(14952322)
 ```
 
-#####BAN: There isn't any documentation for this method. 
+#####WORKER.BAN: There isn't any documentation for this method. 
 
 ```ruby
 worker.ban(worker_id)
 worker.ban(14952322)
 ```
 
-#####DEBAN: There isn't any documentation for this method. 
+#####WORKER.DEBAN: There isn't any documentation for this method. 
 
 ```ruby
 worker.deban(worker_id)
 worker.deban(14952322)
 ```
 
-#####NOTIFY: Sends a notification to a specific contributor. The contributor will see the message under their notifications. 
+#####WORKER.NOTIFY: Sends a notification to a specific contributor. The contributor will see the message under their notifications. 
 
 ```ruby
 worker.notify(worker_id, subject, message)
 worker.notify(23542619, "you earned a bonus!", "good job!")
 ```
 
-#####FLAG: Stops contributors from completing tasks. Their judgments remain in their current state of tainted or non-tainted and will not be thrown away.
+#####WORKER.FLAG: Stops contributors from completing tasks. Their judgments remain in their current state of tainted or non-tainted and will not be thrown away.
 
 ```ruby
 worker.flag(worker_id, reason=nil)
 worker.flag(14952322, "testing")
 ```
 
-#####DEFLAG: Allows a flagged contributor to continue completing tasks.
+#####WORKER.DEFLAG: Allows a flagged contributor to continue completing tasks.
 ```ruby
 worker.deflag(worker_id)
 worker.deflag(14952322)
@@ -385,12 +395,6 @@ job.status["ordered_units"]
 ```ruby
 job.download_csv(type, filename, opts) 
 job.download_csv(full, nil, force:true)
-```
-
-#####WORKERS: http://api.crowdflower.com/v1/jobs/418404/workers
-
-```ruby
-worker = CrowdFlower::Worker.new(job)
 ```
 
 ## Helpful Documentation Links

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 
 1. [Getting Started](#getting-started)
 2. [Usage and Examples](#usage-and-examples)
-3. [Helpful Documentation Links](#api-documentation)
+3. [Helpful Documentation Links](#helpful-documentation-links)
 4. [Contribute](#contribute)
 5. [Team](#team)
 6. [License](#license)

--- a/README.md
+++ b/README.md
@@ -41,146 +41,267 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 
 ## Usage and Examples 
 
-###GET: Get Back Parsed JSON for Any Job
-The get command allows you to access any job's parsed JSON data. To access a job's JSON from your browser, go to api.crowdflower.com/v1/jobs/{your_job_id}.json. Here's an example: http://api.crowdflower.com/v1/jobs/418404.json. 
-
-When you use the get method you can receive all of the JSON for a given job or you can access attributes by using the key name in the get call: 
-
-  ```ruby
-  # GET JOB ID
-  p "NEW JOB ID: #{new_job.get["id"]}"
-  ```
-  
-    $ "NEW JOB ID: 418404"
-  
-###CREATE: Create a Blank Job
-
-  ```ruby
-  require 'crowdflower'
-
-  API_KEY = "YOUR_API_KEY"
-  DOMAIN_BASE = "https://api.crowdflower.com"
-
-  CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
-
-  title = "Crowdshop for Shoes!"
-  new_job = CrowdFlower::Job.create(title)
-  ```
-
-###COPY: Copy an Existing Job
+### Access Job Info
 
 ```ruby
-  require 'crowdflower'
+require 'crowdflower'
 
-  API_KEY = "YOUR_API_KEY"
-  DOMAIN_BASE = "https://api.crowdflower.com"
+API_KEY = "YOUR_API_KEY"
+# API_KEY = "y7AyiTd1F1B8jTvwQaKT"
+DOMAIN_BASE = "https://api.crowdflower.com"
 
-  CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
+CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
 
-  placeholder
-  ```
+job = CrowdFlower::Job.new(job_id)
+job = CrowdFlower::Job.new(418404)
+```
+### Create Blank Job
 
-###UPLOAD: Upload a CSV to Create and Update Units 
+```ruby
+require 'crowdflower'
 
-  ```ruby
-  new_job.upload("crowdshopping.csv", "text/csv") 
-  ```
+API_KEY = "YOUR_API_KEY"
+# API_KEY = "y7AyiTd1F1B8jTvwQaKT"
+DOMAIN_BASE = "https://api.crowdflower.com"
 
-###CHANNELS: Choose Your Contributors
-  ```ruby
+CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
 
-  # Enable Channels
-  code placeholder
-  ```
+title = "Crowdshop for Shoes!"
+job = CrowdFlower::Job.create(title)
+```
 
-###TAGS: Add, Update and Remove Tags to Your Job
-  ```ruby
+### Copy Existing Job
 
-  # Add Tags
-  tags = "shoes", "shopping", "fashion"
-  new_job.add_tags(tags)
+```ruby
+require 'crowdflower'
 
-  # Update Tags - replaces exisiting tags
-  tags = "fun", "glitter"
-  new_job.update_tags(tags)
+API_KEY = "YOUR_API_KEY"
+DOMAIN_BASE = "https://api.crowdflower.com"
+JOB_ID = 418404
 
-  # Remove Tags
-  tags = "fun"
-  new_job.remove_tags(tags)
-  ```
+CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
 
-###LAUNCH & RUN: Job Commands
+job_one = CrowdFlower::Job.new(job_id)
+job_two = job_one.copy
+```
 
-####Pause
-  ```ruby
-  code placeholder
-  ```
+### Available Features (Methods)
 
-####Resume
-  ```ruby
-  code placeholder
-  ```
+```ruby
+#################################################
+# GET - https://crowdflower.com/jobs/418404.json
+#################################################
+job.get["css"]
+job.get["auto_order"]
+job.get["units_remain_finalized"]
+job.get["secret"]
+job.get["support_email"]
+job.get["golds_count"]
+job.get["units_count"]
+job.get["included_countries"]
+job.get["desired_requirements"]
+job.get["max_judgments_per_unit"]
+job.get["instructions"]
+job.get["auto_order_timeout"]
+job.get["public_data"]
+job.get["project_number"]
+job.get["problem"]
+job.get["created_at"]
+job.get["send_judgments_webhook"]
+job.get["expected_judgments_per_unit"]
+job.get["design_verified"]
+job.get["worker_ui_remix"]
+job.get["fields"]
+job.get["completed_at"]
+job.get["auto_order_threshold"]
+job.get["min_unit_confidence"]
+job.get["minimum_account_age_seconds"]
+job.get["units_per_assignment"]
+job.get["execution_mode"]
+job.get["max_judgments_per_worker"]
+job.get["gold"]
+job.get["require_worker_login"]
+job.get["pages_per_assignment"]
+job.get["title"]
+job.get["completed"]
+job.get["order_approved"]
+job.get["minimum_requirements"]
+job.get["max_judgments_per_ip"]
+job.get["confidence_fields"]
+job.get["gold_per_assignment"]
+job.get["alias"]
+job.get["id"]
+job.get["judgments_count"]
+job.get["js"]
+job.get["cml"]
+job.get["excluded_countries"]
+job.get["updated_at"]
+job.get["language"]
+job.get["state"]
+job.get["variable_judgments_mode"]
+job.get["custom_key"]
+job.get["options"]
 
-####Cancel 
-  ```ruby
-  code placeholder
-  ```
+#################################################
+# UPLOAD (data to create units) 
+#################################################
+job.upload(filename, type, opts)
+job.upload("crowdshopping.csv", "text/csv")
 
-####Update
-  ```ruby
-  code placeholder
-  ```
+#################################################
+# CHANNELS - http://api.crowdflower.com/v1/jobs/418404/channels
+#################################################
+job.channels 
+job.enable_channels(channels)
+job.enable_channels("cf_internal")
 
-####Delete
-  ```ruby
-  code placeholder
-  ```
+#################################################
+# TAGS - https://api.crowdflower.com/jobs/418404/tags
+#################################################
+tags = "shoes", "shopping", "fashion"
+job.add_tags(tags)
+job.update_tags("fun", "glitter", "crowdshop")
+job.remove_tags("crowdshop") 
 
-###STATUS: Ping the Status of a Job
-This can also be viewed at api.crowdflower.com/v1/jobs/{your_job_id}/ping, like this one: 
+#################################################
+# UNITS - http://api.crowdflower.com/v1/jobs/418404/units
+#################################################
+unit = CrowdFlower::Unit.new(job)
 
-  ```ruby
-  # view status of all units and judgements:
-  new_job.status 
+# View
+unit.all 
+unit.all.count
+unit.get(unit_id)
 
-  # or veiw specific value with hash key:
-  new_job.status["all_units"]
-  ```
+# Check on a unit
+unit.ping
 
-###DOWNLOAD RESULTS: CSV Download Details
+# View a unit's judgments
+unit.judgments(unit_id)
+unit.judgments(444154130)
 
+# Create from scratch
+unit.create("glitter_color"=>"blue") 
+unit.create("glitter_color"=>"blue", gold: true) 
 
-========
+# Create from copy of existing unit
+unit.copy(unit_id, job_id, data = {})
+unit.copy(444154130, 418404, "glitter_color"=>"blue")
 
-###Units
+# Split
+unit.split(on, with = " ")
 
-####All
-####Get
-####Ping
-####Judgments
-####Create
-####Copy
-####Split
-####Update
-####Make Gold
-####Cancel
-####Delete
-####Request More Judgments
+# Update 
+unit.update(unit_id, params)
+unit.update(444154130, "glitter_color"=>"green")
 
-========
+# Make Gold (make the unit a test question)
+unit.make_gold(unit_id)
 
-###Workers
+# Cancel
+unit.cancel(unit_id)
 
-#####Bonus
-#####Approve
-#####Reject
-#####Ban
-#####Deban
-#####Notifty
-#####Flag
-#####Deflag
+# Delete
+unit.delete(unit_id)
 
-========
+# Request more judgments - nb_judgments = number of additional judgments
+unit.request_more_judgments(unit_id, nb_judgments = 1)
+
+#################################################
+# ORDERS
+#################################################
+order = CrowdFlower::Order.new(job)
+order.debit(units_count, channels)
+order.debit(6, "all")
+
+#################################################
+# PAUSE - can only call on running jobs
+#################################################
+job.pause
+
+#################################################
+# RESUME - can only call on paused or complete jobs
+#################################################
+job.resume
+
+#################################################
+# CANCEL - only on running or paused jobs
+#################################################
+job.cancel
+
+#################################################
+# UPDATE - access of the json attributes (see GET)
+#################################################
+job.update
+job.update("project_number"=>"PN123")
+
+#################################################
+# DELETE
+#################################################
+job.delete
+
+#################################################
+# JUDGMENTS - http://api.crowdflower.com/v1/jobs/418404/units/judgments
+#################################################
+judgment = CrowdFlower::Judgment.new(job) 
+judgment.all
+judgment.get(judgment_id)
+judgment.get(1239592918)
+
+# Admin only
+judgment.reject(judgment_id)
+judgment.reject(1239592918)
+
+# Return every judgment for the given unit
+job.units.judgments(unit_id_number) 
+job.units.judgments(444154130) 
+
+#################################################
+# LEGEND - http://api.crowdflower.com/v1/jobs/418404/legend
+#################################################
+job.legend
+
+#################################################
+# STATUS - parsed json response or access attributes like GET
+#################################################
+job.status
+job.status["golden_units"]
+job.status["all_judgments"]
+job.status["tainted_judgments"]
+job.status["completed_units_estimate"]
+job.status["needed_judgments"]
+job.status["all_units"]
+job.status["completed_non_gold_estimate"]
+job.status["completed_gold_estimate"]
+job.status["ordered_units"]
+
+#################################################
+# DOWNLOAD_CSV - get csv or zip back of job results
+#################################################
+job.download_csv(type, filename, opts) 
+job.download_csv(full, nil, force:true)
+
+#################################################
+# WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
+#################################################
+worker = CrowdFlower::Worker.new(job)
+
+worker.bonus(worker_id, amount, reason=nil)
+
+worker.approve(worker_id)
+
+worker.reject(worker_id)
+
+worker.ban(worker_id)
+
+worker.deban(worker_id)
+
+worker.notify(worker_id, subject, message)
+
+worker.flag(worker_id, reason=nil)
+
+worker.deflag(worker_id)
+```
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,45 @@
-CrowdFlower API Gem
-========
-Currently this is a toolkit for interacting with the CrowdFlower REST API. It may potentially become a complete Ruby gem for accessing and editing [CrowdFlower](http://crowdflower.com.com) jobs. 
+# ruby-crowdflower
 
-## Table of Contents
+A toolkit for interacting with CrowdFlower via the REST API.
 
-1. [Getting Started](#getting-started)
-2. [Usage and Examples](#usage-and-examples)
-3. [Helpful Documentation Links](#helpful-documentation-links)
-4. [Contribute](#contribute)
-5. [Team](#team)
-6. [License](#license)
+This is alpha software. Have fun!
 
-## Getting Started
+Example Usage
+-------------
 
-#####Require this gem in your ruby file:
-    
-    require 'crowdflower'
+Specifiy either your api key or a yaml file containing the key:
+  
+  CrowdFlower.connect!( 'CrowdFlower.yml' )
+  
+Upload a CSV file for a job:
 
-#####Or add this line to your application's Gemfile:
+  CrowdFlower::Job.upload( File.dirname(__FILE__) + "/data.csv", "text/csv" )
 
-    $ gem 'crowdflower'
+Copy an existing job into a new one:
+  
+  new_job = job.copy( :all_units => true )
+  
+Check the status of a job:
 
-#####Then execute:
-
-    $ bundle install
-
-#####Or install it yourself as:
-
-    $ gem install crowdflower
+  job.status["tainted_judgments"]
 
 
-This gem makes use of [CrowdFlower's API](http://success.crowdflower.com/customer/portal/articles/1288323-api-documentation). To find your API key, click on your name in the upper right hand corner and select "Account" from the drop down. To create an account click [here](https://id.crowdflower.com/registrations/new?redirect_url=https%3A%2F%2Fcrowdflower.com%2Fjobs&app=make&__hssc=14529640.6.1397164984954&__hstc=14529640.8f31cd290788fdc43f4da6707700cde6.1396463439689.1397160539873.1397164984954.16&hsCtaTracking=c85b8d58-818e-4f19-a27e-83e8f55da890%7C583ca9bc-a025-43b9-806a-b329df96a8c6).
+
+Contributing
+------------
+
+1. Fork ruby-crowdflower
+2. Create a topic branch - `git checkout -b my_branch`
+3. Make your feature addition or bug fix and add tests for it.
+4. Commit, but do not mess with the rakefile, version, or history.
+5. Push to your branch - `git push origin my_branch`
+6. Create an Issue with a link to your branch
+
+Copyright
+---------
+
+Copyright &copy; 2014 [CrowdFlower](http://www.crowdflower.com/). See LICENSE for details.
+" from the drop down. To create an account click [here](https://id.crowdflower.com/registrations/new?redirect_url=https%3A%2F%2Fcrowdflower.com%2Fjobs&app=make&__hssc=14529640.6.1397164984954&__hstc=14529640.8f31cd290788fdc43f4da6707700cde6.1396463439689.1397160539873.1397164984954.16&hsCtaTracking=c85b8d58-818e-4f19-a27e-83e8f55da890%7C583ca9bc-a025-43b9-806a-b329df96a8c6).
 
 #####Specify your api key directly in your code or store it in a yaml file:
 

--- a/README.md
+++ b/README.md
@@ -86,10 +86,9 @@ job_two = job_one.copy
 
 ### Available Features (Methods)
 
+#####GET - https://crowdflower.com/jobs/418404.json
+
 ```ruby
-#################################################
-# GET - https://crowdflower.com/jobs/418404.json
-#################################################
 job.get["css"]
 job.get["auto_order"]
 job.get["units_remain_finalized"]
@@ -140,111 +139,152 @@ job.get["state"]
 job.get["variable_judgments_mode"]
 job.get["custom_key"]
 job.get["options"]
+```
 
-#################################################
-# UPLOAD (data to create units) 
-#################################################
+#####UPLOAD (data to create units) 
+
+```ruby
 job.upload(filename, type, opts)
 job.upload("crowdshopping.csv", "text/csv")
+```
 
-#################################################
-# CHANNELS - http://api.crowdflower.com/v1/jobs/418404/channels
-#################################################
+#####CHANNELS - http://api.crowdflower.com/v1/jobs/418404/channels
+
+```ruby
 job.channels 
 job.enable_channels(channels)
 job.enable_channels("cf_internal")
+```
 
-#################################################
-# TAGS - https://api.crowdflower.com/jobs/418404/tags
-#################################################
+#####TAGS - https://api.crowdflower.com/jobs/418404/tags
+
+```ruby
 tags = "shoes", "shopping", "fashion"
 job.add_tags(tags)
 job.update_tags("fun", "glitter", "crowdshop")
 job.remove_tags("crowdshop") 
+```
 
-#################################################
-# UNITS - http://api.crowdflower.com/v1/jobs/418404/units
-#################################################
+#####UNITS - http://api.crowdflower.com/v1/jobs/418404/units
+
+```ruby
 unit = CrowdFlower::Unit.new(job)
+```
 
-# View
+#####View
+
+```ruby
 unit.all 
 unit.all.count
 unit.get(unit_id)
+```
+#####Check on a unit
 
-# Check on a unit
+```ruby
 unit.ping
+```
 
-# View a unit's judgments
+#####View a unit's judgments
+
+```ruby
 unit.judgments(unit_id)
 unit.judgments(444154130)
+```
 
-# Create from scratch
+#####Create from scratch
+
+```ruby
 unit.create("glitter_color"=>"blue") 
 unit.create("glitter_color"=>"blue", gold: true) 
 
-# Create from copy of existing unit
+#####Create from copy of existing unit
+
+```ruby
 unit.copy(unit_id, job_id, data = {})
 unit.copy(444154130, 418404, "glitter_color"=>"blue")
 
-# Split
+#####Split
 unit.split(on, with = " ")
 
-# Update 
+#####Update 
+
+```ruby
 unit.update(unit_id, params)
 unit.update(444154130, "glitter_color"=>"green")
+```
 
-# Make Gold (make the unit a test question)
+#####Make Gold (make the unit a test question)
+
+```ruby
 unit.make_gold(unit_id)
+```
 
-# Cancel
+#####Cancel
+
+```ruby
 unit.cancel(unit_id)
+```
 
-# Delete
+#####Delete
+
+```ruby
 unit.delete(unit_id)
+```
 
-# Request more judgments - nb_judgments = number of additional judgments
+#####Request more judgments - nb_judgments = number of additional judgments
+
+```ruby
 unit.request_more_judgments(unit_id, nb_judgments = 1)
+```
 
-#################################################
-# ORDERS
-#################################################
+#####ORDERS
+
+```ruby
 order = CrowdFlower::Order.new(job)
 order.debit(units_count, channels)
 order.debit(6, "all")
+```
 
-#################################################
-# PAUSE - can only call on running jobs
-#################################################
+#####PAUSE - can only call on running jobs
+
+```ruby
 job.pause
+```
 
-#################################################
-# RESUME - can only call on paused or complete jobs
-#################################################
+#####RESUME - can only call on paused or complete jobs
+
+```ruby
 job.resume
+```
 
-#################################################
-# CANCEL - only on running or paused jobs
-#################################################
+#####CANCEL - only on running or paused jobs
+
+```ruby
 job.cancel
+```
 
-#################################################
-# UPDATE - access of the json attributes (see GET)
-#################################################
+#####UPDATE - access of the json attributes (see GET)
+
+```ruby
 job.update
 job.update("project_number"=>"PN123")
+```
 
-#################################################
-# DELETE
-#################################################
+#####DELETE
+
+```ruby
 job.delete
+```
 
-#################################################
-# WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
-#################################################
+#####WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
+
+```ruby
 worker = CrowdFlower::Worker.new(job) 
+```
 
-# Award a bonus in cents, 200 for $2.00
+#####Award a bonus in cents, 200 for $2.00
+
+```ruby
 worker.bonus(worker_id, amount, reason=nil)
 worker.bonus(23542619, 10, "good job!")
 
@@ -268,10 +308,11 @@ worker.flag(14952322, "testing")
 
 worker.deflag(worker_id)
 worker.deflag(14952322)
+```
 
-#################################################
-# JUDGMENTS - http://api.crowdflower.com/v1/jobs/418404/units/judgments
-#################################################
+#####JUDGMENTS - http://api.crowdflower.com/v1/jobs/418404/units/judgments
+
+```ruby
 judgment = CrowdFlower::Judgment.new(job) 
 judgment.all
 judgment.get(judgment_id)
@@ -284,15 +325,17 @@ judgment.reject(1239592918)
 # Return every judgment for the given unit
 job.units.judgments(unit_id_number) 
 job.units.judgments(444154130) 
+```
 
-#################################################
-# LEGEND - http://api.crowdflower.com/v1/jobs/418404/legend
-#################################################
+#####LEGEND - http://api.crowdflower.com/v1/jobs/418404/legend
+
+```ruby
 job.legend
+```
 
-#################################################
-# STATUS - parsed json response or access attributes like GET
-#################################################
+#####STATUS - parsed json response or access attributes like GET
+
+```ruby
 job.status
 job.status["golden_units"]
 job.status["all_judgments"]
@@ -303,16 +346,18 @@ job.status["all_units"]
 job.status["completed_non_gold_estimate"]
 job.status["completed_gold_estimate"]
 job.status["ordered_units"]
+```
 
-#################################################
-# DOWNLOAD_CSV - get csv or zip back of job results
-#################################################
+#####DOWNLOAD_CSV - get csv or zip back of job results
+
+```ruby
 job.download_csv(type, filename, opts) 
 job.download_csv(full, nil, force:true)
+```
 
-#################################################
-# WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
-#################################################
+#####WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
+
+```ruby
 worker = CrowdFlower::Worker.new(job)
 
 worker.bonus(worker_id, amount, reason=nil)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,11 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 6. [License](#license)
 
 ## Install
+Require it in your ruby file:
+    
+    require 'crowdflower'
 
-Add this line to your application's Gemfile:
+Or add this line to your application's Gemfile:
 
     $ gem 'crowdflower'
 
@@ -32,10 +35,10 @@ This gem makes use of [CrowdFlower's Human API](http://success.crowdflower.com/c
 #####Specifiy either your api key or a yaml file containing the key:
 
 ```ruby
-CrowdFlower.connect!( 'CrowdFlower.yml' )
+CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
-## Breakdown
+## Classes Breakdown
 
 * [Base](#base)
 * [Job](#job)
@@ -43,43 +46,84 @@ CrowdFlower.connect!( 'CrowdFlower.yml' )
 * [Order](#order)
 * [Unit](#unit)
 * [Worker](#worker)
-* [Crowdflower](#crowdflower)
 
-###Base
+###Base Class
 
-####Placeholder
-
-###Job
+###Job Class
   * Create
-  * Get
-  * Units
-  * Copy
-  * Deban
-  * Status
-  * Upload
-  * Legend
-  * Download CSV --> Note to self: test csv vs zip
-  * Pause
-  * Resume
-  * Cancel 
-  * Update
-  * Delete
-  * Channels
-  * Enable Channels
-  * Tags
-  * Update Tags
-  * Add Tags
-  * Remove Tags
+  ```ruby
+  require 'crowdflower'
 
-###Judgment
+  API_KEY = "UGTKhMZMLi_ZdsqoFJ3V"
+  DOMAIN_BASE = "https://api.crowdflower.com"
+
+  CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
+
+  title = "Crowdshop for Shoes!"
+  new_job = CrowdFlower::Job.create(title)
+  ```
+  * Get
+  ```ruby
+  # GET JOB ID
+  p "NEW JOB ID: #{new_job.get["id"]}"
+  ```
+
+  * Units: Had some issues calling units on job
+
+  * Copy
+
+  * Status
+  ```ruby
+  new_job.status 
+  # or specify hash key
+  new_job.status["all_units"]
+  ```
+
+  * Upload: Two methods, need to explore more
+
+  * Legend: Not sure what this is used for
+
+  * Download CSV: Still not sure why some are .csv and some are zip files
+
+  * Pause
+
+  * Resume
+
+  * Cancel 
+
+  * Update
+
+  * Delete
+
+  * Channels
+
+  * Enable Channels
+
+  * Tags
+  ```ruby
+
+  # Add Tags
+  tags = "shoes", "shopping", "fashion"
+  new_job.add_tags(tags)
+
+  # Update Tags - replaces exisiting tags
+  tags = "fun", "glitter"
+  new_job.update_tags(tags)
+
+  # Remove Tags
+  tags = "fun"
+  new_job.remove_tags(tags)
+  ```
+
+###Judgment Class
   * All
   * Get
   * Reject
 
-###Order
+###Order Class
   * Debit
 
-###Unit
+###Unit Class
   * All
   * Get
   * Ping
@@ -93,7 +137,7 @@ CrowdFlower.connect!( 'CrowdFlower.yml' )
   * Delete
   * Request More Judgments
 
-###Worker
+###Worker Class
 
 ####Methods, Examples and Bugs
   * Bonus
@@ -104,10 +148,6 @@ CrowdFlower.connect!( 'CrowdFlower.yml' )
   * Notifty
   * Flag
   * Deflag
-
-###Crowdflower
-
-####Does something with httparty
 
 ## Contribute
 
@@ -120,7 +160,7 @@ CrowdFlower.connect!( 'CrowdFlower.yml' )
 
 ## Team
 
-This gem is made by CrowdFlower engineers. Check out the [CrowdFlower Team](http://www.crowdflower.com/team)!
+Check out the [CrowdFlower Team](http://www.crowdflower.com/team)!
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 
 1. [Getting Started](#getting-started)
 2. [Usage and Examples](#usage-and-examples)
-3. [Contribute](#contribute)
-4. [Team](#team)
-5. [License](#license)
+3. [API Documentation](#api-documentation)
+4. [Contribute](#contribute)
+5. [Team](#team)
+6. [License](#license)
 
 ## Getting Started
 
@@ -239,6 +240,36 @@ job.update("project_number"=>"PN123")
 job.delete
 
 #################################################
+# WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
+#################################################
+worker = CrowdFlower::Worker.new(job) 
+
+# Award a bonus in cents, 200 for $2.00
+worker.bonus(worker_id, amount, reason=nil)
+worker.bonus(23542619, 10, "good job!")
+
+worker.approve(worker_id)
+worker.approve(14952322) 
+
+worker.reject(worker_id)
+worker.reject(14952322)
+
+worker.ban(worker_id)
+worker.ban(14952322)
+
+worker.deban(worker_id)
+worker.deban(14952322)
+
+worker.notify(worker_id, subject, message)
+worker.notify(23542619, "you earned a bonus!", "good job!")
+
+worker.flag(worker_id, reason=nil)
+worker.flag(14952322, "testing")
+
+worker.deflag(worker_id)
+worker.deflag(14952322)
+
+#################################################
 # JUDGMENTS - http://api.crowdflower.com/v1/jobs/418404/units/judgments
 #################################################
 judgment = CrowdFlower::Judgment.new(job) 
@@ -300,6 +331,9 @@ worker.flag(worker_id, reason=nil)
 
 worker.deflag(worker_id)
 ```
+
+## Helpful Documentation
+Judgments: http://success.crowdflower.com/customer/portal/articles/1366723-job-settings---judgments
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -4,57 +4,54 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 
 ## Table of Contents
 
-1. [Intstall](#Install)
-2. [Usage](#usage)
-3. [Breakdown](#breakdown)
-4. [Contribute](#contribute)
-5. [Team](#team)
-6. [License](#license)
+1. [Getting Started](#getting-started)
+2. [Usage and Examples](#usage-and-examples)
+3. [Contribute](#contribute)
+4. [Team](#team)
+5. [License](#license)
 
-## Install
-Require it in your ruby file:
+## Getting Started
+
+#####Require this gem in your ruby file:
     
     require 'crowdflower'
 
-Or add this line to your application's Gemfile:
+#####Or add this line to your application's Gemfile:
 
     $ gem 'crowdflower'
 
-And then execute:
+#####Then execute:
 
     $ bundle install
 
-Or install it yourself as:
+#####Or install it yourself as:
 
     $ gem install crowdflower
 
-## Usage
+This gem makes use of [CrowdFlower's API](http://success.crowdflower.com/customer/portal/articles/1288323-api-documentation). To find your API key, click on your name in the upper right hand corner and select "Account" from the drop down. To create an account click [here](https://id.crowdflower.com/registrations/new?redirect_url=https%3A%2F%2Fcrowdflower.com%2Fjobs&app=make&__hssc=14529640.6.1397164984954&__hstc=14529640.8f31cd290788fdc43f4da6707700cde6.1396463439689.1397160539873.1397164984954.16&hsCtaTracking=c85b8d58-818e-4f19-a27e-83e8f55da890%7C583ca9bc-a025-43b9-806a-b329df96a8c6).
 
-This gem makes use of [CrowdFlower's Human API](http://success.crowdflower.com/customer/portal/articles/1288323-api-documentation). Please check out our [Terms and Conditions](http://www.crowdflower.com/legal) page for detailed usage and licensing information.
-
-#####Specifiy either your api key or a yaml file containing the key:
+#####Specifiy your api key directly in your code or store it in a yaml file:
 
 ```ruby
+API_KEY = "YOUR_API_KEY"
+
 CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
-## Classes Breakdown
+## Usage and Examples 
 
-* [Base](#base)
-* [Job](#job)
-* [Judgment](#judgment)
-* [Order](#order)
-* [Unit](#unit)
-* [Worker](#worker)
+* [Jobs](#job)
+* [Judgments](#judgment)
+* [Units](#unit)
+* [Workers](#worker)
 
-###Base Class
+###Jobs
 
-###Job Class
-  * Create
+#####Create
   ```ruby
   require 'crowdflower'
 
-  API_KEY = "UGTKhMZMLi_ZdsqoFJ3V"
+  API_KEY = "YOUR_API_KEY"
   DOMAIN_BASE = "https://api.crowdflower.com"
 
   CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
@@ -62,44 +59,52 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
   title = "Crowdshop for Shoes!"
   new_job = CrowdFlower::Job.create(title)
   ```
-  * Get
+
+#####Get Information on Any Job
+The get command allows you to access any job's parsed JSON data. To access a job's JSON from your browser, go to api.crowdflower.com/v1/jobs/{your_job_id}.json. Here's an example: http://api.crowdflower.com/v1/jobs/418404.json. 
+
+When you use the get method you can receive all of the JSON for a given job or you can access attributes by using the key name in the get call: 
+
   ```ruby
   # GET JOB ID
   p "NEW JOB ID: #{new_job.get["id"]}"
   ```
+  
+    $ "NEW JOB ID: 418404"
+  
 
-  * Units: Had some issues calling units on job
+#####Units: Had some issues calling units on job
 
-  * Copy
+#####Copy
 
-  * Status
+#####Status
   ```ruby
   new_job.status 
   # or specify hash key
   new_job.status["all_units"]
   ```
 
-  * Upload: Two methods, need to explore more
+#####Upload: Two methods, need to explore more
 
-  * Legend: Not sure what this is used for
+#####Legend: Not sure what this is used for
 
-  * Download CSV: Still not sure why some are .csv and some are zip files
+#####Download CSV: Still not sure why some are .csv and some are zip files
 
-  * Pause
+#####Pause
 
-  * Resume
+#####Resume
 
-  * Cancel 
+#####Cancel 
 
-  * Update
+#####Update
 
-  * Delete
+#####Delete
 
-  * Channels
+#####Channels
 
-  * Enable Channels
+#####Enable Channels
 
-  * Tags
+#####Tags
   ```ruby
 
   # Add Tags
@@ -115,39 +120,45 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
   new_job.remove_tags(tags)
   ```
 
-###Judgment Class
-  * All
-  * Get
-  * Reject
+========
 
-###Order Class
-  * Debit
+###Judgments
 
-###Unit Class
-  * All
-  * Get
-  * Ping
-  * Judgments
-  * Create
-  * Copy
-  * Split
-  * Update
-  * Make Gold
-  * Cancel
-  * Delete
-  * Request More Judgments
+#####All
+#####Get
+#####Reject
 
-###Worker Class
+========
 
-####Methods, Examples and Bugs
-  * Bonus
-  * Approve
-  * Reject
-  * Ban
-  * Deban
-  * Notifty
-  * Flag
-  * Deflag
+###Units
+
+#####All
+#####Get
+#####Ping
+#####Judgments
+#####Create
+#####Copy
+#####Split
+#####Update
+#####Make Gold
+#####Cancel
+#####Delete
+#####Request More Judgments
+
+========
+
+###Workers
+
+#####Bonus
+#####Approve
+#####Reject
+#####Ban
+#####Deban
+#####Notifty
+#####Flag
+#####Deflag
+
+========
 
 ## Contribute
 
@@ -184,3 +195,5 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Please review our [Terms and Conditions](http://www.crowdflower.com/legal) page for detailed api usage and licensing information.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 ```
 
 ## Usage and Examples 
-#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples (must be signed in to view).
+#####[Example Job](https://api.crowdflower.com/v1/jobs/418404/) - referenced throught the following examples (must be signed in to view).3
 
 ### Access Job Info
 
@@ -225,19 +225,19 @@ unit.update(444154130, "glitter_color"=>"green")
 unit.make_gold(unit_id)
 ```
 
-#####Cancel
+#####CANCEL
 
 ```ruby
 unit.cancel(unit_id)
 ```
 
-#####Delete
+#####DELETE
 
 ```ruby
 unit.delete(unit_id)
 ```
 
-#####Request more judgments - nb_judgments = number of additional judgments
+#####REQUEST_MORE_JUDGMENTS: nb_judgments = number of additional judgments
 
 ```ruby
 unit.request_more_judgments(unit_id, nb_judgments = 1)
@@ -288,30 +288,56 @@ job.delete
 worker = CrowdFlower::Worker.new(job) 
 ```
 
-#####Award a bonus in cents, 200 for $2.00
+#####BONUS: Award a bonus in cents, 200 for $2.00 and (optionally) add a message
 
 ```ruby
 worker.bonus(worker_id, amount, reason=nil)
-worker.bonus(23542619, 10, "good job!")
+worker.bonus(23542619, 200, "You shoe shop like a pro! Thanks for the awesome answers!")
+```
 
+#####APPROVE: There isn't any documentation for this method. 
+
+```ruby
 worker.approve(worker_id)
 worker.approve(14952322) 
+```
+#####REJECT: Stops contributors from completing tasks, and removes the contributors judgments from a job. Try to only use when a job is running, otherwise the completed job will lose judgments and be unable to collect replacement ones. 
 
+```ruby
 worker.reject(worker_id)
 worker.reject(14952322)
+```
 
+#####BAN: There isn't any documentation for this method. 
+
+```ruby
 worker.ban(worker_id)
 worker.ban(14952322)
+```
 
+#####DEBAN: There isn't any documentation for this method. 
+
+```ruby
 worker.deban(worker_id)
 worker.deban(14952322)
+```
 
+#####NOTIFY: Sends a notification to a specific contributor. The contributor will see the message under their notifications. 
+
+```ruby
 worker.notify(worker_id, subject, message)
 worker.notify(23542619, "you earned a bonus!", "good job!")
+```
 
+#####FLAG: Stops contributors from completing tasks. Their judgments remain in their current state of tainted or non-tainted and will not be thrown away.
+
+```ruby
 worker.flag(worker_id, reason=nil)
 worker.flag(14952322, "testing")
+```
 
+#####DEFLAG: Allows a flagged contributor to continue completing tasks.
+```ruby
 worker.deflag(worker_id)
 worker.deflag(14952322)
 ```
@@ -339,7 +365,7 @@ job.units.judgments(444154130)
 job.legend
 ```
 
-#####STATUS - parsed json response or access attributes like GET
+#####STATUS: parsed JSON response or access attributes like GET
 
 ```ruby
 job.status
@@ -354,37 +380,25 @@ job.status["completed_gold_estimate"]
 job.status["ordered_units"]
 ```
 
-#####DOWNLOAD_CSV - get csv or zip back of job results
+#####DOWNLOAD_CSV: Downloads a CSV of the job with results, sometimes as csv and sometimes as a zip containing the CSV.
 
 ```ruby
 job.download_csv(type, filename, opts) 
 job.download_csv(full, nil, force:true)
 ```
 
-#####WORKERS - http://api.crowdflower.com/v1/jobs/418404/workers
+#####WORKERS: http://api.crowdflower.com/v1/jobs/418404/workers
 
 ```ruby
 worker = CrowdFlower::Worker.new(job)
-
-worker.bonus(worker_id, amount, reason=nil)
-
-worker.approve(worker_id)
-
-worker.reject(worker_id)
-
-worker.ban(worker_id)
-
-worker.deban(worker_id)
-
-worker.notify(worker_id, subject, message)
-
-worker.flag(worker_id, reason=nil)
-
-worker.deflag(worker_id)
 ```
 
-## Helpful Documentation
-Judgments: http://success.crowdflower.com/customer/portal/articles/1366723-job-settings---judgments
+## Helpful Documentation Links
+
+[Job Settings](http://success.crowdflower.com/customer/portal/articles/1373615-contributors---behavior-settings)
+[Data Management](http://success.crowdflower.com/customer/portal/articles/1288308-data)
+[Judgments](http://success.crowdflower.com/customer/portal/articles/1366723-job-settings---judgments)
+[Workers](http://success.crowdflower.com/customer/portal/articles/1288319-contributors---active-contributors)
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -305,12 +305,6 @@ worker.bonus(worker_id, amount, reason=nil)
 worker.bonus(23542619, 200, "You shoe shop like a pro! Thanks for the awesome answers!")
 ```
 
-#####WORKER.APPROVE: There isn't any documentation for this method. 
-
-```ruby
-worker.approve(worker_id)
-worker.approve(14952322) 
-```
 #####WORKER.REJECT: Stops contributors from completing tasks, and removes the contributors judgments from a job. Try to only use when a job is running, otherwise the completed job will lose judgments and be unable to collect replacement ones. 
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -196,15 +196,20 @@ unit.judgments(444154130)
 ```ruby
 unit.create("glitter_color"=>"blue") 
 unit.create("glitter_color"=>"blue", gold: true) 
+```
 
 #####Create from copy of existing unit
 
 ```ruby
 unit.copy(unit_id, job_id, data = {})
 unit.copy(444154130, 418404, "glitter_color"=>"blue")
+```
 
 #####Split
+
+```ruby
 unit.split(on, with = " ")
+```
 
 #####Update 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 require 'crowdflower'
 
 API_KEY = "YOUR_API_KEY"
-# API_KEY = "y7AyiTd1F1B8jTvwQaKT"
 DOMAIN_BASE = "https://api.crowdflower.com"
 
 CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
@@ -61,7 +60,6 @@ job = CrowdFlower::Job.new(418404)
 require 'crowdflower'
 
 API_KEY = "YOUR_API_KEY"
-# API_KEY = "y7AyiTd1F1B8jTvwQaKT"
 DOMAIN_BASE = "https://api.crowdflower.com"
 
 CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently this is a toolkit for interacting with the CrowdFlower REST API. It ma
 
     $ gem install crowdflower
 
+
 This gem makes use of [CrowdFlower's API](http://success.crowdflower.com/customer/portal/articles/1288323-api-documentation). To find your API key, click on your name in the upper right hand corner and select "Account" from the drop down. To create an account click [here](https://id.crowdflower.com/registrations/new?redirect_url=https%3A%2F%2Fcrowdflower.com%2Fjobs&app=make&__hssc=14529640.6.1397164984954&__hstc=14529640.8f31cd290788fdc43f4da6707700cde6.1396463439689.1397160539873.1397164984954.16&hsCtaTracking=c85b8d58-818e-4f19-a27e-83e8f55da890%7C583ca9bc-a025-43b9-806a-b329df96a8c6).
 
 #####Specifiy your api key directly in your code or store it in a yaml file:
@@ -40,14 +41,20 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
 
 ## Usage and Examples 
 
-* [Jobs](#job)
-* [Judgments](#judgment)
-* [Units](#unit)
-* [Workers](#worker)
+###GET: Get Back Parsed JSON for Any Job
+The get command allows you to access any job's parsed JSON data. To access a job's JSON from your browser, go to api.crowdflower.com/v1/jobs/{your_job_id}.json. Here's an example: http://api.crowdflower.com/v1/jobs/418404.json. 
 
-###Jobs
+When you use the get method you can receive all of the JSON for a given job or you can access attributes by using the key name in the get call: 
 
-#####Create
+  ```ruby
+  # GET JOB ID
+  p "NEW JOB ID: #{new_job.get["id"]}"
+  ```
+  
+    $ "NEW JOB ID: 418404"
+  
+###CREATE: Create a Blank Job
+
   ```ruby
   require 'crowdflower'
 
@@ -60,51 +67,33 @@ CrowdFlower.connect!( 'CrowdFlower.yaml' )
   new_job = CrowdFlower::Job.create(title)
   ```
 
-#####Get Information on Any Job
-The get command allows you to access any job's parsed JSON data. To access a job's JSON from your browser, go to api.crowdflower.com/v1/jobs/{your_job_id}.json. Here's an example: http://api.crowdflower.com/v1/jobs/418404.json. 
+###COPY: Copy an Existing Job
 
-When you use the get method you can receive all of the JSON for a given job or you can access attributes by using the key name in the get call: 
+```ruby
+  require 'crowdflower'
 
-  ```ruby
-  # GET JOB ID
-  p "NEW JOB ID: #{new_job.get["id"]}"
-  ```
-  
-    $ "NEW JOB ID: 418404"
-  
+  API_KEY = "YOUR_API_KEY"
+  DOMAIN_BASE = "https://api.crowdflower.com"
 
-#####Units: Had some issues calling units on job
+  CrowdFlower::Job.connect! API_KEY, DOMAIN_BASE
 
-#####Copy
-
-#####Status
-  ```ruby
-  new_job.status 
-  # or specify hash key
-  new_job.status["all_units"]
+  placeholder
   ```
 
-#####Upload: Two methods, need to explore more
+###UPLOAD: Upload a CSV to Create and Update Units 
 
-#####Legend: Not sure what this is used for
+  ```ruby
+  new_job.upload("crowdshopping.csv", "text/csv") 
+  ```
 
-#####Download CSV: Still not sure why some are .csv and some are zip files
+###CHANNELS: Choose Your Contributors
+  ```ruby
 
-#####Pause
+  # Enable Channels
+  code placeholder
+  ```
 
-#####Resume
-
-#####Cancel 
-
-#####Update
-
-#####Delete
-
-#####Channels
-
-#####Enable Channels
-
-#####Tags
+###TAGS: Add, Update and Remove Tags to Your Job
   ```ruby
 
   # Add Tags
@@ -120,30 +109,63 @@ When you use the get method you can receive all of the JSON for a given job or y
   new_job.remove_tags(tags)
   ```
 
-========
+###LAUNCH & RUN: Job Commands
 
-###Judgments
+####Pause
+  ```ruby
+  code placeholder
+  ```
 
-#####All
-#####Get
-#####Reject
+####Resume
+  ```ruby
+  code placeholder
+  ```
+
+####Cancel 
+  ```ruby
+  code placeholder
+  ```
+
+####Update
+  ```ruby
+  code placeholder
+  ```
+
+####Delete
+  ```ruby
+  code placeholder
+  ```
+
+###STATUS: Ping the Status of a Job
+This can also be viewed at api.crowdflower.com/v1/jobs/{your_job_id}/ping, like this one: 
+
+  ```ruby
+  # view status of all units and judgements:
+  new_job.status 
+
+  # or veiw specific value with hash key:
+  new_job.status["all_units"]
+  ```
+
+###DOWNLOAD RESULTS: CSV Download Details
+
 
 ========
 
 ###Units
 
-#####All
-#####Get
-#####Ping
-#####Judgments
-#####Create
-#####Copy
-#####Split
-#####Update
-#####Make Gold
-#####Cancel
-#####Delete
-#####Request More Judgments
+####All
+####Get
+####Ping
+####Judgments
+####Create
+####Copy
+####Split
+####Update
+####Make Gold
+####Cancel
+####Delete
+####Request More Judgments
 
 ========
 

--- a/lib/crowdflower/base.rb
+++ b/lib/crowdflower/base.rb
@@ -185,3 +185,5 @@ module CrowdFlower
   end
   
 end
+
+

--- a/lib/crowdflower/worker.rb
+++ b/lib/crowdflower/worker.rb
@@ -20,10 +20,6 @@ module CrowdFlower
       connection.post( "#{resource_uri}/#{worker_id}/bonus", :body => params )
     end
     
-    def approve( worker_id )
-      connection.put( "#{resource_uri}/#{worker_id}/approve", :headers => { "Content-Length" => "0" } )
-    end
-    
     def reject( worker_id )
       connection.put( "#{resource_uri}/#{worker_id}/reject", :headers => { "Content-Length" => "0" } )
     end


### PR DESCRIPTION
Probably should have created this branch from the readme branch but the approve method removal is in its own commit...@arvel let me know if you'd like a git redo. 

This PR is really just to remove the worker.approve method because it was only functional when we used mechanical turk. I also updated the readme to remove the approve method, which is why all the other readme changes are here too. 
