### PR TITLE
Don't use query string in the worker's api

### DIFF
--- a/lib/crowdflower/worker.rb
+++ b/lib/crowdflower/worker.rb
@@ -29,7 +29,7 @@ module CrowdFlower
         :subject => subject,
         :message => message
       }
-      connection.post( "#{resource_uri}/#{worker_id}/notify", :query => params )
+      connection.post( "#{resource_uri}/#{worker_id}/notify", :body => params )
     end
 
     def notify(worker_id, message)


### PR DESCRIPTION
Query string makes your API 500 on long messages. It's usually best practice to use `body` rather than `query` for anything that is not a `GET`. 
